### PR TITLE
Fix a possible deadlock during service initialization.

### DIFF
--- a/src/main/java/com/lbayer/appup/registry/AppupContext.java
+++ b/src/main/java/com/lbayer/appup/registry/AppupContext.java
@@ -396,11 +396,11 @@ class AppupContext implements Context, EventContext
     @Override
     public NamingEnumeration<Binding> listBindings(String name) throws NamingException
     {
+        // force lookup
+        lookupMultiple(name);
+
         synchronized (registrations)
         {
-            // force lookup
-            lookupMultiple(name);
-
             List<AppupContext.Registration> regs = registrations.get(name);
             if (regs == null || regs.isEmpty())
             {


### PR DESCRIPTION
`listBindings` will lock `registrations` and call `lookupMultiple`.
`lookupMultiple` can try lock `writeLock` if the service is not yet initialized.

When Thread-1 needs to lock `registrations`,
e.g. `lookup` cannot find a service in `registrations` and call `lookupMultiple`,
it is possible that
Thread-1 locks `writeLock` in `lookupMultiple` and before it can lock `registrations`,
Thread-2 calls `listBindings` and locks `registrations`.
The threads are now in a deadlock situation.